### PR TITLE
for release 1.0.9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+1.0.9 - config vars for binaries can be set by user
 1.0.7 - switch to rst
 1.0.6 - updated spider to 25.02 to fix segfault bug of intel binaries
 1.0.4 - removed xmipp dependency in the viewer, add protocols.conf

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ b) Developer's version
 
 SPIDER binaries will be installed automatically with the plugin, but you can also link an existing installation. 
 Default installation path assumed is ``software/em/spider-25.02``, if you want to change it, set *SPIDER_HOME* in ``scipion.conf`` file to the folder where the SPIDER is installed. Additional information about using SPIDER with MPI can be found on a separate `page <https://github.com/scipion-em/scipion-em-spider/wiki/How-to-Install-MPI>`_. Unfortunately, at the moment we do not support MPI in our SPIDER wrappers, since it requires a lot of effort to refactor almost all protocols. :(
+Depending on you CPU type you might want to change the default binary from ``spider_linux_mp_intel64`` to a different one by explicitly setting *SPIDER* variable. Similarly you can modify *SPIDER_MPI* variable (default ``spider_linux_mpi_opt64``).
 
 To check the installation, simply run one of the following Scipion tests:
 

--- a/spider/__init__.py
+++ b/spider/__init__.py
@@ -45,6 +45,8 @@ class Plugin(pyworkflow.em.Plugin):
     @classmethod
     def _defineVariables(cls):
         cls._defineEmVar(SPIDER_HOME, 'spider-25.02')
+        cls._defineVar(SPIDER, 'spider_linux_mp_intel64')
+        cls._defineVar(SPIDER_MPI, 'spider_linux_mpi_opt64')
 
     @classmethod
     def getEnviron(cls):
@@ -77,7 +79,11 @@ class Plugin(pyworkflow.em.Plugin):
 
     @classmethod
     def getProgram(cls, mpi=False):
-        program = SPIDER if mpi is False else SPIDER_MPI
+        if mpi:
+            program = os.path.basename(cls.getVar(SPIDER_MPI))
+        else:
+            program = os.path.basename(cls.getVar(SPIDER))
+
         cmd = abspath(join(cls.getEnviron()[SPBIN_DIR], program))
 
         return str(cmd)

--- a/spider/constants.py
+++ b/spider/constants.py
@@ -26,15 +26,15 @@
 
 # Define the version of the 'spider' Python module, that can also be
 # imported from setup.py for PyPI distribution
-__version__ = '1.0.8'
+__version__ = '1.0.9'
 
 # ----------------- Constants values --------------------------------------
 SPIDER_HOME = 'SPIDER_HOME'
 SPPROC_DIR = 'SPPROC_DIR'
 SPMAN_DIR = 'SPMAN_DIR'
 SPBIN_DIR = 'SPBIN_DIR'
-SPIDER = 'spider_linux_mp_intel64'
-SPIDER_MPI = 'spider_linux_mpi_opt64'
+SPIDER = 'SPIDER'
+SPIDER_MPI = 'SPIDER_MPI'
 
 # spider documentation url
 SPIDER_DOCS = 'https://spider.wadsworth.org/spider_doc/spider/docs/man/'

--- a/spider/protocols/protocol_align_apsr.py
+++ b/spider/protocols/protocol_align_apsr.py
@@ -51,7 +51,7 @@ class SpiderProtAlignAPSR(SpiderProtAlign):
         cgOption = form.getParam('cgOption')
         cgOption.config(condition='False')
 
-        form.addParallelSection(threads=1, mpi=0)
+        form.addParallelSection(threads=2, mpi=0)
         
     def alignParticlesStep(self, innerRadius, outerRadius):
         """ Apply the selected filter to particles. 

--- a/spider/scripts/25.02/mda/apsr4class.msa
+++ b/spider/scripts/25.02/mda/apsr4class.msa
@@ -5,7 +5,7 @@
 ; ---------------- Parameters ----------------
 [inner-rad] = 5        ; first ring radius for alignment, pixels
 [outer-rad] = 44       ; expected object radius, pixels
-[nummps]    = 0        ; number of processors to use (0=all)
+[nummps]    = 2        ; number of processors to use (0=all)
 ;;[obj-diam] = 88        ; expected object diameter, pixels
 
 ; ---------------- Input files ----------------

--- a/spider/scripts/25.02/mda/apsr4class.msa
+++ b/spider/scripts/25.02/mda/apsr4class.msa
@@ -81,6 +81,10 @@ md
 set mp
 [nummps]
 
+md
+set threads
+[nummps]
+
 ; run reference-free alignment
 AP SR
 [unaligned]        ; particles to be aligned


### PR DESCRIPTION
1) config vars for binaries can be set by user
2) set fftw3 threads in the script of ap sr

The 2) might reduce frequency of failing the test in the buildbot. Or not :) Worth a try